### PR TITLE
feat: add per-mod scale slider to HUD elements

### DIFF
--- a/src/main/java/dsns/betterhud/BetterHUDGUI.java
+++ b/src/main/java/dsns/betterhud/BetterHUDGUI.java
@@ -1,6 +1,5 @@
 package dsns.betterhud;
 
-import com.mojang.blaze3d.vertex.PoseStack;
 import dsns.betterhud.util.BaseMod;
 import dsns.betterhud.util.CustomText;
 import dsns.betterhud.util.ModSettings;
@@ -132,10 +131,10 @@ public class BetterHUDGUI implements ClientTickEvents.StartTick {
         int x,
         int y
     ) {
-        PoseStack poses = drawContext.pose();
-        poses.pushPose();
-        poses.translate(x, y, 0);
-        poses.scale(text.scale, text.scale, 1.0f);
+        var poses = drawContext.pose();
+        poses.pushMatrix();
+        poses.translate((float) x, (float) y);
+        poses.scale(text.scale, text.scale);
 
         int w = (client.font.width(text.text) - 1) + (horizontalPadding * 2);
         int h = (client.font.lineHeight - 1) + (verticalPadding * 2);
@@ -150,7 +149,7 @@ public class BetterHUDGUI implements ClientTickEvents.StartTick {
             true
         );
 
-        poses.popPose();
+        poses.popMatrix();
     }
 
     private int scaledElementWidth(CustomText text) {

--- a/src/main/java/dsns/betterhud/BetterHUDGUI.java
+++ b/src/main/java/dsns/betterhud/BetterHUDGUI.java
@@ -1,5 +1,6 @@
 package dsns.betterhud;
 
+import com.mojang.blaze3d.vertex.PoseStack;
 import dsns.betterhud.util.BaseMod;
 import dsns.betterhud.util.CustomText;
 import dsns.betterhud.util.ModSettings;
@@ -79,48 +80,31 @@ public class BetterHUDGUI implements ClientTickEvents.StartTick {
 
         for (CustomText text : topLeftText) {
             drawString(drawContext, text, x, y);
-
-            y +=
-                (client.font.lineHeight - 1) +
-                (verticalPadding * 2) +
-                lineHeight;
+            y += scaledElementHeight(text) + lineHeight;
         }
 
         y = client.getWindow().getGuiScaledHeight() - verticalMargin;
 
         for (CustomText text : bottomLeftList) {
-            y -= (client.font.lineHeight - 1) + (verticalPadding * 2);
+            y -= scaledElementHeight(text);
             drawString(drawContext, text, x, y);
             y -= lineHeight;
         }
 
         y = verticalMargin;
         for (CustomText text : topRightText) {
-            int offset =
-                (client.font.width(text.text) - 1) +
-                (horizontalPadding * 2) +
-                horizontalMargin;
+            int offset = scaledElementWidth(text) + horizontalMargin;
             x = client.getWindow().getGuiScaledWidth() - offset;
             drawString(drawContext, text, x, y);
-
-            y +=
-                (client.font.lineHeight - 1) +
-                (verticalPadding * 2) +
-                lineHeight;
+            y += scaledElementHeight(text) + lineHeight;
         }
 
         y = client.getWindow().getGuiScaledHeight() - verticalMargin;
         for (CustomText text : bottomRightText) {
-            int offset =
-                (client.font.width(text.text) - 1) +
-                (horizontalPadding * 2) +
-                horizontalMargin;
+            int offset = scaledElementWidth(text) + horizontalMargin;
             x = client.getWindow().getGuiScaledWidth() - offset;
-
-            y -= (client.font.lineHeight - 1) + (verticalPadding * 2);
-
+            y -= scaledElementHeight(text);
             drawString(drawContext, text, x, y);
-
             y -= lineHeight;
         }
 
@@ -130,17 +114,15 @@ public class BetterHUDGUI implements ClientTickEvents.StartTick {
 
             int maxX =
                 client.getWindow().getGuiScaledWidth() -
-                (horizontalPadding * 2) -
-                (client.font.width(text.text) - 1);
+                scaledElementWidth(text);
             int maxY =
                 client.getWindow().getGuiScaledHeight() -
-                (verticalPadding * 2) -
-                (client.font.lineHeight - 1);
+                scaledElementHeight(text);
 
-            int scaledX = (int) (xPercent * maxX);
-            int scaledY = (int) (yPercent * maxY);
+            int posX = (int) (xPercent * maxX);
+            int posY = (int) (yPercent * maxY);
 
-            drawString(drawContext, text, scaledX, scaledY);
+            drawString(drawContext, text, posX, posY);
         }
     }
 
@@ -150,23 +132,34 @@ public class BetterHUDGUI implements ClientTickEvents.StartTick {
         int x,
         int y
     ) {
-        drawContext.fill(
-            x,
-            y,
-            x +
-                (client.font.width(text.text) - 1) +
-                (horizontalPadding * 2),
-            y + (client.font.lineHeight - 1) + (verticalPadding * 2),
-            text.backgroundColor
-        );
+        PoseStack poses = drawContext.pose();
+        poses.pushPose();
+        poses.translate(x, y, 0);
+        poses.scale(text.scale, text.scale, 1.0f);
 
+        int w = (client.font.width(text.text) - 1) + (horizontalPadding * 2);
+        int h = (client.font.lineHeight - 1) + (verticalPadding * 2);
+
+        drawContext.fill(0, 0, w, h, text.backgroundColor);
         drawContext.text(
             client.font,
             text.text,
-            x + horizontalPadding,
-            y + verticalPadding,
+            horizontalPadding,
+            verticalPadding,
             text.color,
             true
         );
+
+        poses.popPose();
+    }
+
+    private int scaledElementWidth(CustomText text) {
+        int w = (client.font.width(text.text) - 1) + (horizontalPadding * 2);
+        return (int) (w * text.scale);
+    }
+
+    private int scaledElementHeight(CustomText text) {
+        int h = (client.font.lineHeight - 1) + (verticalPadding * 2);
+        return (int) (h * text.scale);
     }
 }

--- a/src/main/java/dsns/betterhud/ModMenu.java
+++ b/src/main/java/dsns/betterhud/ModMenu.java
@@ -88,6 +88,12 @@ public class ModMenu implements ModMenuApi {
                                 .build()
                         );
                     } else if (setting.getType().equals("double")) {
+                        double min = Double.parseDouble(
+                            setting.getPossibleValues()[0]
+                        );
+                        double max = Double.parseDouble(
+                            setting.getPossibleValues()[1]
+                        );
                         category.addEntry(
                             entryBuilder
                                 .startDoubleField(
@@ -99,6 +105,8 @@ public class ModMenu implements ModMenuApi {
                                         setting.getDefaultValue()
                                     )
                                 )
+                                .setMin(min)
+                                .setMax(max)
                                 .setSaveConsumer(value ->
                                     setting.setValue(String.valueOf(value))
                                 )

--- a/src/main/java/dsns/betterhud/util/CustomText.java
+++ b/src/main/java/dsns/betterhud/util/CustomText.java
@@ -5,6 +5,7 @@ public class CustomText {
     public String text;
     public int color; // colors are in ARGB format
     public int backgroundColor; // colors are in ARGB format
+    public float scale = 1.0f;
     public boolean customPosition = false;
     public int customX = 0;
     public int customY = 0;
@@ -21,6 +22,7 @@ public class CustomText {
             settings.getSetting("Text Color").getColorValue(),
             settings.getSetting("Background Color").getColorValue()
         );
+        this.scale = (float) settings.getSetting("Scale").getDoubleValue();
     }
 
     public CustomText(String text, int color, ModSettings settings) {

--- a/src/main/java/dsns/betterhud/util/ModSettings.java
+++ b/src/main/java/dsns/betterhud/util/ModSettings.java
@@ -28,6 +28,7 @@ public class ModSettings {
         settings.put("Custom Position", Setting.createBooleanSetting(false));
         settings.put("Custom X", Setting.createIntegerSetting(0, 0, 100));
         settings.put("Custom Y", Setting.createIntegerSetting(0, 0, 100));
+        settings.put("Scale", Setting.createDoubleSetting(1.0, 0.5, 3.0));
         settings.put("Text Color", Setting.createColorSetting(0xffffffff));
         settings.put(
             "Background Color",


### PR DESCRIPTION
## Summary

- Adds a **Scale** setting (0.5x–3.0x, default 1.0x) to every HUD mod via `ModSettings`
- Applies scaling via PoseStack matrix transformation in `BetterHUDGUI.drawString`, so both the background and text are scaled uniformly
- All layout calculations (top-left, top-right, bottom-left, bottom-right, and custom-position stacking) now use the scaled element dimensions so elements don't overlap when scaled
- The Scale field is surfaced in the Mod Menu config screen with min/max bounds (0.5–3.0) enforced

## Test plan

- [x] Launch the game and open Mod Menu → BetterHUD settings
- [x] Set FPS mod Scale to 2.0 — confirm the FPS element renders at double size and stays flush to the corner
- [ ] Set Coordinates mod Scale to 0.5 — confirm the element renders at half size
- [ ] Mix scales across mods in the same orientation (e.g. top-left) — confirm elements stack without overlap
- [ ] Test Custom Position with a non-1.0 scale — confirm the element stays within screen bounds at 0% and 100%
- [ ] Reload the game — confirm Scale values persist via the config file

https://claude.ai/code/session_01SxKxSuPq5hqaTDD9tDJQk1


---
_Generated by [Claude Code](https://claude.ai/code/session_01SxKxSuPq5hqaTDD9tDJQk1)_