### PR TITLE
feat: update to Minecraft 26.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,12 +29,10 @@ dependencies {
 	
 	implementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
-	// Fabric API. This is technically optional, but you probably want it anyway.
-	implementation include(fabricApi.module("fabric-api-base", project.fabric_api_version))
-	implementation include(fabricApi.module("fabric-rendering-v1", project.fabric_api_version))
-	
-	implementation include("com.terraformersmc:modmenu:${project.modmenu_version}")
-	implementation include("me.shedaniel.cloth:cloth-config-fabric:${project.cloth_config_version}") {
+	implementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_api_version}"
+
+	implementation "com.terraformersmc:modmenu:${project.modmenu_version}"
+	implementation("me.shedaniel.cloth:cloth-config-fabric:${project.cloth_config_version}") {
         exclude(group: "net.fabricmc.fabric-api")
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,16 +7,16 @@ org.gradle.configuration-cache=false
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=26.1
-loader_version=0.19.2
-loom_version=1.16-SNAPSHOT
+minecraft_version=26.2
+loader_version=0.19.3
+loom_version=1.17-SNAPSHOT
 
 # Mod Properties
-mod_version=2.1.0
+mod_version=2.1.1
 maven_group=dsns.betterhud
 archives_base_name=betterhud
 
 # Dependencies
-fabric_api_version=0.145.1+26.1
+fabric_api_version=0.154.0+26.2
 modmenu_version=18.0.0-alpha.8
 cloth_config_version=26.1.154

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/dsns/betterhud/BetterHUDGUI.java
+++ b/src/main/java/dsns/betterhud/BetterHUDGUI.java
@@ -72,7 +72,7 @@ public class BetterHUDGUI implements ClientTickEvents.StartTick {
         DeltaTracker tickCounter
     ) {
         if (client.getDebugOverlay().showDebugScreen()) return;
-        if (client.options.hideGui) return;
+        if (client.gui.hud.isHidden()) return;
 
         int x = horizontalMargin;
         int y = verticalMargin;

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -23,6 +23,9 @@
 	"depends": {
 		"fabricloader": ">=0.19",
 		"minecraft": ">=26",
-		"java": ">=25"
+		"java": ">=25",
+		"fabric-api": "*",
+		"modmenu": "*",
+		"cloth-config2": "*"
 	}
 }


### PR DESCRIPTION
## Summary
- Update to Minecraft 26.2: bump `minecraft_version` to 26.2, Fabric Loader to 0.19.3, Fabric API to 0.154.0+26.2, and Loom to 1.17-SNAPSHOT (mod version 2.1.1)
- Upgrade Gradle wrapper from 9.4.1 to 9.5.1, required by Loom 1.17 snapshots
- Fix compile error from the 26.2 mapping change: `Options.hideGui` was removed, replaced with `client.gui.hud.isHidden()`

## Test plan
- [x] `./gradlew build` succeeds
