### PR TITLE
Add automated publish workflow for Modrinth and CurseForge

### DIFF
--- a/.github/scripts/generate-matrices.sh
+++ b/.github/scripts/generate-matrices.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
 # Derives the CI job matrices from supported-versions.json (the single source
 # of truth for supported Minecraft versions) and writes them to GITHUB_OUTPUT:
-#  - build:  one entry per build variant       -> { mc, java }
-#  - launch: one entry per launchable version  -> { mc, java, pregen_world }
+#  - build:   one entry per build variant       -> { mc, java }
+#  - launch:  one entry per launchable version  -> { mc, java, pregen_world }
+#  - publish: one entry per build variant       -> { mc, java, game_versions, range }
 # pregen_world marks versions whose Fabric API has no client gametest module;
 # their launch test needs a pre-generated world (see generate-test-world.sh).
+# game_versions is the newline-separated list of Minecraft versions the
+# variant's jar covers (fed to mc-publish), range is its human-readable form
+# for the release name (e.g. "1.21-1.21.5").
 set -euo pipefail
 
 JSON=supported-versions.json
@@ -22,13 +26,23 @@ while IFS=$'\t' read -r mc variant gametest; do
 done < <(jq -r 'to_entries[] | [.key, .value.variant, (.value.clientGametest | tostring)] | @tsv' "$JSON")
 
 build="[]"
+publish="[]"
 while read -r variant; do
 	java="$(java_for_variant "$variant")"
 	build="$(jq -c --arg mc "$variant" --arg java "$java" \
 		'. + [{mc: $mc, java: $java}]' <<<"$build")"
+	game_versions="$(jq -r --arg v "$variant" \
+		'[to_entries[] | select(.value.variant == $v) | .key] | join("\n")' "$JSON")"
+	range="$(jq -r --arg v "$variant" \
+		'[to_entries[] | select(.value.variant == $v) | .key]
+		 | if length == 1 then .[0] else "\(first)-\(last)" end' "$JSON")"
+	publish="$(jq -c --arg mc "$variant" --arg java "$java" --arg gv "$game_versions" --arg range "$range" \
+		'. + [{mc: $mc, java: $java, game_versions: $gv, range: $range}]' <<<"$publish")"
 done < <(jq -r '[.[].variant] | reduce .[] as $v ([]; if index($v) then . else . + [$v] end) | .[]' "$JSON")
 
 echo "build=$build" >> "$GITHUB_OUTPUT"
 echo "launch=$launch" >> "$GITHUB_OUTPUT"
-echo "build matrix:  $build"
-echo "launch matrix: $launch"
+echo "publish=$publish" >> "$GITHUB_OUTPUT"
+echo "build matrix:   $build"
+echo "launch matrix:  $launch"
+echo "publish matrix: $publish"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -130,7 +130,7 @@ jobs:
           curseforge-token: ${{ inputs.platforms != 'modrinth' && secrets.CURSEFORGE_TOKEN || '' }}
 
           files: versions/${{ matrix.mc }}/build/libs/!(*-@(dev|sources|javadoc)).jar
-          name: BetterHUD ${{ needs.matrices.outputs.mod_version }} (${{ matrix.range }})
+          name: BetterHUD ${{ needs.matrices.outputs.mod_version }} (Minecraft ${{ matrix.range }})
           version: ${{ needs.matrices.outputs.mod_version }}+mc${{ matrix.mc }}
           version-type: ${{ inputs.version_type }}
           changelog: ${{ inputs.changelog }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,147 @@
+# Publishes the mod to Modrinth and CurseForge on demand: bump `mod_version`
+# in gradle.properties, push, then run this workflow from the Actions tab.
+# It builds every Stonecutter variant and uploads each release jar as its own
+# version on both platforms, selecting exactly the Minecraft versions that jar
+# covers — driven by supported-versions.json, the same single source of truth
+# the build and launch-test matrices use.
+#
+# Required repository secrets (Settings -> Secrets and variables -> Actions):
+#  - MODRINTH_TOKEN:   Modrinth PAT with the "Create versions" scope
+#                      (https://modrinth.com/settings/pats)
+#  - CURSEFORGE_TOKEN: CurseForge API token
+#                      (https://legacy.curseforge.com/account/api-tokens)
+#
+# This workflow only builds; correctness on every supported Minecraft version
+# is already covered by the launch tests that run on every push (build.yml),
+# so make sure the commit you release from is green there first.
+
+name: publish
+on:
+  workflow_dispatch:
+    inputs:
+      changelog:
+        description: 'Changelog (Markdown, shown on both platforms)'
+        required: true
+        type: string
+      version_type:
+        description: 'Release channel'
+        required: true
+        type: choice
+        default: release
+        options:
+          - release
+          - beta
+          - alpha
+      platforms:
+        description: 'Where to publish'
+        required: true
+        type: choice
+        default: both
+        options:
+          - both
+          - modrinth
+          - curseforge
+
+permissions:
+  contents: read
+
+# Never let two release runs interleave their uploads.
+concurrency:
+  group: publish
+  cancel-in-progress: false
+
+jobs:
+  matrices:
+    name: compute publish matrix
+    runs-on: ubuntu-24.04
+    outputs:
+      publish: ${{ steps.gen.outputs.publish }}
+      mod_version: ${{ steps.version.outputs.mod_version }}
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v6
+
+      - name: generate matrices from supported-versions.json
+        id: gen
+        run: bash .github/scripts/generate-matrices.sh
+
+      - name: read mod version from gradle.properties
+        id: version
+        run: |
+          version="$(grep -oP '^mod_version=\K.+' gradle.properties)"
+          echo "mod_version=$version" >> "$GITHUB_OUTPUT"
+          echo "Releasing BetterHUD $version"
+
+      - name: check the required tokens are configured
+        # mc-publish silently skips a platform whose token is empty, which
+        # would make a run "succeed" while publishing nothing — fail early
+        # instead if a selected platform has no token.
+        env:
+          PLATFORMS: ${{ inputs.platforms }}
+          MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
+          CURSEFORGE_TOKEN: ${{ secrets.CURSEFORGE_TOKEN }}
+        run: |
+          if [ "$PLATFORMS" != "curseforge" ] && [ -z "$MODRINTH_TOKEN" ]; then
+            echo "::error::MODRINTH_TOKEN secret is not set"; exit 1
+          fi
+          if [ "$PLATFORMS" != "modrinth" ] && [ -z "$CURSEFORGE_TOKEN" ]; then
+            echo "::error::CURSEFORGE_TOKEN secret is not set"; exit 1
+          fi
+
+  publish:
+    name: publish mc${{ matrix.mc }}
+    runs-on: ubuntu-24.04
+    needs: matrices
+    strategy:
+      # Publish one variant at a time, oldest first (supported-versions.json
+      # order), so the newest-Minecraft version ends up as the most recently
+      # uploaded — and a failure stops before uploading the rest.
+      max-parallel: 1
+      fail-fast: true
+      matrix:
+        include: ${{ fromJson(needs.matrices.outputs.publish) }}
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v6
+
+      - name: validate gradle wrapper
+        uses: gradle/actions/wrapper-validation@v6
+
+      - name: setup jdk ${{ matrix.java }}
+        uses: actions/setup-java@v5
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: 'microsoft'
+
+      - name: make gradle wrapper executable
+        run: chmod +x ./gradlew
+
+      - name: build :${{ matrix.mc }}:build
+        run: ./gradlew :${{ matrix.mc }}:build --stacktrace
+
+      - name: publish to modrinth and curseforge
+        uses: Kir-Antipov/mc-publish@v3.3
+        with:
+          # An empty token makes mc-publish skip that platform, which is how
+          # the "platforms" input narrows the run to a single site.
+          modrinth-id: betterhudfabric
+          modrinth-token: ${{ inputs.platforms != 'curseforge' && secrets.MODRINTH_TOKEN || '' }}
+          curseforge-id: 1375095
+          curseforge-token: ${{ inputs.platforms != 'modrinth' && secrets.CURSEFORGE_TOKEN || '' }}
+
+          files: versions/${{ matrix.mc }}/build/libs/!(*-@(dev|sources|javadoc)).jar
+          name: BetterHUD ${{ needs.matrices.outputs.mod_version }} (${{ matrix.range }})
+          version: ${{ needs.matrices.outputs.mod_version }}+mc${{ matrix.mc }}
+          version-type: ${{ inputs.version_type }}
+          changelog: ${{ inputs.changelog }}
+
+          loaders: fabric
+          game-versions: ${{ matrix.game_versions }}
+          java: ${{ matrix.java }}
+          dependencies: |
+            fabric-api(required)
+            cloth-config(required)
+            modmenu(required)
+
+          retry-attempts: 2
+          retry-delay: 10000

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ truth for every supported Minecraft version. It drives:
   under XVFB, enters a survival world with the HUD active, screenshots it,
   and fails on any crash; the screenshots are posted as a grid on the PR),
 - the per-version runtime mods used by those launch tests,
-- the Modrinth upload guide (see below).
+- the publish workflow's per-jar Minecraft version lists and the manual
+  Modrinth upload guide (see below).
 
 ### Adding a new Minecraft version
 
@@ -64,9 +65,21 @@ truth for every supported Minecraft version. It drives:
 To launch-test one version locally:
 `./gradlew :launchtest:runProductionClientGameTest -PtestMcVersion=<version>`
 
-### Releasing to Modrinth
+### Releasing to Modrinth and CurseForge
 
-Run `./gradlew modrinthBundle` (or download the `modrinth-upload` artifact
-from any CI run). It produces `build/modrinth/` containing every release jar
-plus `UPLOAD.md`, which lists exactly which Minecraft versions to select for
-each jar when creating the Modrinth versions.
+Bump `mod_version` in `gradle.properties`, push, wait for CI to go green,
+then run the **publish** workflow from the Actions tab (Run workflow). It
+builds every variant and uploads each release jar as its own version on
+Modrinth and CurseForge, selecting exactly the Minecraft versions that jar
+covers (from `supported-versions.json`). The workflow asks for a changelog,
+a release channel (release/beta/alpha), and which platforms to publish to.
+
+It needs two repository secrets: `MODRINTH_TOKEN` (a
+[Modrinth PAT](https://modrinth.com/settings/pats) with the "Create versions"
+scope) and `CURSEFORGE_TOKEN` (a
+[CurseForge API token](https://legacy.curseforge.com/account/api-tokens)).
+
+For a manual upload instead, run `./gradlew modrinthBundle` (or download the
+`modrinth-upload` artifact from any CI run). It produces `build/modrinth/`
+containing every release jar plus `UPLOAD.md`, which lists exactly which
+Minecraft versions to select for each jar.


### PR DESCRIPTION
## Summary
This PR adds a new GitHub Actions workflow that automates publishing BetterHUD to both Modrinth and CurseForge platforms. Previously, releases required manual uploads; now they can be published on-demand through the Actions tab with a single workflow dispatch.

## Key Changes

- **New publish workflow** (`.github/workflows/publish.yml`): Automated release pipeline that:
  - Builds all Stonecutter variants
  - Uploads each release jar as a separate version to Modrinth and/or CurseForge
  - Automatically selects the correct Minecraft versions for each jar based on `supported-versions.json`
  - Supports configurable changelog, release channel (release/beta/alpha), and target platforms
  - Enforces sequential uploads with concurrency controls to prevent interleaving
  - Validates required API tokens before attempting publication

- **Enhanced matrix generation script** (`.github/scripts/generate-matrices.sh`): Extended to compute a new `publish` matrix that includes:
  - `game_versions`: Newline-separated list of Minecraft versions each variant supports
  - `range`: Human-readable version range for release names (e.g., "1.21-1.21.5")

- **Updated documentation** (`README.md`): Revised release instructions to reflect the new automated workflow, including:
  - Steps to trigger the publish workflow from the Actions tab
  - Required repository secrets (Modrinth PAT and CurseForge API token)
  - Fallback instructions for manual uploads via `./gradlew modrinthBundle`

## Implementation Details

- The workflow uses `mc-publish` action to handle platform-specific uploads
- Token validation occurs early to fail fast if required secrets are missing
- Builds are performed sequentially (max-parallel: 1) to ensure oldest Minecraft versions are uploaded first, with the newest version ending up as the most recent upload
- The workflow only builds; correctness validation is delegated to existing launch tests in `build.yml`

https://claude.ai/code/session_01Gw2SqwSvrHSQcDDXSH2Vn9