### PR TITLE
Capture BetterHUD settings menu in launch tests

### DIFF
--- a/.github/scripts/publish-screenshots.sh
+++ b/.github/scripts/publish-screenshots.sh
@@ -5,7 +5,8 @@
 # URLs) in a PR comment and in the job summary.
 #
 # Leaves the normalized screenshots in screenshots-publish/ for the comment
-# step: <sha>/mc-<version>-survival.png and <sha>/mc-<version>-title.png.
+# step: <sha>/mc-<version>-survival.png, <sha>/mc-<version>-settings.png and
+# <sha>/mc-<version>-title.png.
 #
 # Required env: GITHUB_TOKEN, GITHUB_REPOSITORY, GITHUB_RUN_ID, GITHUB_SHA
 set -euo pipefail
@@ -34,7 +35,7 @@ mkdir -p "$PUBLISH"
 
 for dir in shots/*/; do
 	mc="$(basename "$dir")"
-	for kind in survival-world title-screen; do
+	for kind in survival-world settings-menu title-screen; do
 		src="$(find "$dir" -name "*betterhud-$kind.png" -print -quit)"
 		if [ -n "$src" ]; then
 			cp "$src" "$PUBLISH/mc-$mc-${kind%%-*}.png"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@
 # Both job matrices are generated from supported-versions.json — add a version
 # there (see README) and every job picks it up.
 
-name: build
+name: Build
 on: push
 
 # contents: write lets the screenshot report push to the ci-screenshots branch,
@@ -21,21 +21,21 @@ permissions:
 
 jobs:
   matrices:
-    name: compute matrices
+    name: Compute Matrices
     runs-on: ubuntu-24.04
     outputs:
       build: ${{ steps.gen.outputs.build }}
       launch: ${{ steps.gen.outputs.launch }}
     steps:
-      - name: checkout repository
+      - name: Checkout Repository
         uses: actions/checkout@v6
 
-      - name: generate matrices from supported-versions.json
+      - name: Generate Matrices from supported-versions.json
         id: gen
         run: bash .github/scripts/generate-matrices.sh
 
   build:
-    name: build mc${{ matrix.mc }}
+    name: Build MC ${{ matrix.mc }}
     runs-on: ubuntu-24.04
     needs: matrices
     strategy:
@@ -43,25 +43,25 @@ jobs:
       matrix:
         include: ${{ fromJson(needs.matrices.outputs.build) }}
     steps:
-      - name: checkout repository
+      - name: Checkout Repository
         uses: actions/checkout@v6
 
-      - name: validate gradle wrapper
+      - name: Validate Gradle Wrapper
         uses: gradle/actions/wrapper-validation@v6
 
-      - name: setup jdk ${{ matrix.java }}
+      - name: Set Up JDK ${{ matrix.java }}
         uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java }}
           distribution: 'microsoft'
 
-      - name: make gradle wrapper executable
+      - name: Make Gradle Wrapper Executable
         run: chmod +x ./gradlew
 
-      - name: build :${{ matrix.mc }}:build
+      - name: Build :${{ matrix.mc }}:build
         run: ./gradlew :${{ matrix.mc }}:build --stacktrace
 
-      - name: upload jar
+      - name: Upload Jar
         uses: actions/upload-artifact@v7
         with:
           name: betterhud-mc${{ matrix.mc }}
@@ -76,7 +76,7 @@ jobs:
   # that version's dedicated server, and the client auto-joins it instead of
   # creating one through the gametest API.
   launch-test:
-    name: launch mc${{ matrix.mc }}
+    name: Launch MC ${{ matrix.mc }}
     runs-on: ubuntu-24.04
     needs: matrices
     timeout-minutes: 40
@@ -85,36 +85,36 @@ jobs:
       matrix:
         include: ${{ fromJson(needs.matrices.outputs.launch) }}
     steps:
-      - name: checkout repository
+      - name: Checkout Repository
         uses: actions/checkout@v6
 
-      - name: validate gradle wrapper
+      - name: Validate Gradle Wrapper
         uses: gradle/actions/wrapper-validation@v6
 
-      - name: setup jdk ${{ matrix.java }}
+      - name: Set Up JDK ${{ matrix.java }}
         uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java }}
           distribution: 'microsoft'
 
-      - name: make gradle wrapper executable
+      - name: Make Gradle Wrapper Executable
         run: chmod +x ./gradlew
 
-      - name: install xvfb
+      - name: Install Xvfb
         # Provides a virtual display so the Minecraft client can launch headlessly.
         run: sudo apt-get update && sudo apt-get install -y xvfb
 
-      - name: generate singleplayer test world
+      - name: Generate Singleplayer Test World
         if: ${{ matrix.pregen_world }}
         run: bash .github/scripts/generate-test-world.sh ${{ matrix.mc }}
 
-      - name: launch minecraft ${{ matrix.mc }} with mod
+      - name: Launch Minecraft ${{ matrix.mc }} with Mod
         run: ./gradlew :launchtest:runProductionClientGameTest -PtestMcVersion=${{ matrix.mc }} --stacktrace
 
-      - name: check survival world screenshot was taken
+      - name: Check Survival World Screenshot Was Taken
         run: test -n "$(find launchtest/run/screenshots -name '*betterhud-survival-world.png' -print -quit 2>/dev/null)"
 
-      - name: upload screenshots
+      - name: Upload Screenshots
         # Consumed by the screenshot-report job below.
         if: always()
         uses: actions/upload-artifact@v7
@@ -123,7 +123,7 @@ jobs:
           path: launchtest/run/screenshots/
           if-no-files-found: ignore
 
-      - name: upload game logs
+      - name: Upload Game Logs
         if: always()
         uses: actions/upload-artifact@v7
         with:
@@ -132,20 +132,20 @@ jobs:
           if-no-files-found: ignore
 
   screenshot-report:
-    name: screenshot report
+    name: Screenshot Report
     runs-on: ubuntu-24.04
     needs: launch-test
     if: ${{ always() }}
     steps:
-      - name: checkout repository
+      - name: Checkout Repository
         uses: actions/checkout@v6
 
-      - name: publish screenshots to the ci-screenshots branch
+      - name: Publish Screenshots to the ci-screenshots Branch
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash .github/scripts/publish-screenshots.sh
 
-      - name: post screenshot grid to pull request and job summary
+      - name: Post Screenshot Grid to Pull Request and Job Summary
         uses: actions/github-script@v8
         with:
           script: |
@@ -170,8 +170,8 @@ jobs:
             const marker = '<!-- betterhud-launch-screenshots -->';
             const body = [
               marker,
-              '### Client launch test',
-              `The game launched and entered a survival singleplayer world with the HUD active, on every supported Minecraft version, for \`${context.sha.slice(0, 7)}\`. A ❌ means that version's launch test did not produce a screenshot — check its job. Title-screen screenshots and game logs are in the run artifacts.`,
+              '### Client Launch Test',
+              `Automated launch verification for \`${context.sha.slice(0, 7)}\`: on every supported Minecraft version, the client launched successfully and entered a survival singleplayer world with the HUD active. A ❌ indicates that a version's launch test did not produce a screenshot — see that version's job for details. Title-screen screenshots and game logs are available in the workflow run artifacts.`,
               '',
               `<table>\n${rows}</table>`,
             ].join('\n');
@@ -212,16 +212,16 @@ jobs:
   # which lists exactly which Minecraft versions to select for each jar when
   # uploading to Modrinth. Download the "modrinth-upload" artifact and follow it.
   modrinth-bundle:
-    name: modrinth bundle
+    name: Modrinth Bundle
     runs-on: ubuntu-24.04
     steps:
-      - name: checkout repository
+      - name: Checkout Repository
         uses: actions/checkout@v6
 
-      - name: validate gradle wrapper
+      - name: Validate Gradle Wrapper
         uses: gradle/actions/wrapper-validation@v6
 
-      - name: setup jdk 21 and 25
+      - name: Set Up JDK 21 and 25
         uses: actions/setup-java@v5
         with:
           java-version: |
@@ -229,13 +229,13 @@ jobs:
             25
           distribution: 'microsoft'
 
-      - name: make gradle wrapper executable
+      - name: Make Gradle Wrapper Executable
         run: chmod +x ./gradlew
 
-      - name: build all variants and write the upload guide
+      - name: Build All Variants and Write the Upload Guide
         run: ./gradlew modrinthBundle --stacktrace "-Porg.gradle.java.installations.paths=$JAVA_HOME_21_X64,$JAVA_HOME_25_X64"
 
-      - name: upload modrinth bundle
+      - name: Upload Modrinth Bundle
         uses: actions/upload-artifact@v7
         with:
           name: modrinth-upload

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,8 @@
 # on EVERY supported Minecraft version concurrently: each launch job boots a
 # real production Fabric client under XVFB with the covering variant's jar and
 # version-matched runtime mods, enters a survival singleplayer world with the
-# HUD active, screenshots it, and fails if anything crashes on the way.
+# HUD active, opens the BetterHUD settings menu, screenshots both, and fails
+# if anything crashes on the way.
 # The screenshot report job embeds all screenshots in a PR comment (via the
 # ci-screenshots branch) and in the job summary, and the modrinth bundle job
 # packages the release jars with their per-jar Minecraft version lists.
@@ -111,8 +112,10 @@ jobs:
       - name: Launch Minecraft ${{ matrix.mc }} with Mod
         run: ./gradlew :launchtest:runProductionClientGameTest -PtestMcVersion=${{ matrix.mc }} --stacktrace
 
-      - name: Check Survival World Screenshot Was Taken
-        run: test -n "$(find launchtest/run/screenshots -name '*betterhud-survival-world.png' -print -quit 2>/dev/null)"
+      - name: Check Required Screenshots Were Taken
+        run: |
+          test -n "$(find launchtest/run/screenshots -name '*betterhud-survival-world.png' -print -quit 2>/dev/null)"
+          test -n "$(find launchtest/run/screenshots -name '*betterhud-settings-menu.png' -print -quit 2>/dev/null)"
 
       - name: Upload Screenshots
         # Consumed by the screenshot-report job below.
@@ -156,11 +159,13 @@ jobs:
             const base = `https://raw.githubusercontent.com/${context.repo.owner}/${context.repo.repo}/ci-screenshots/${context.sha}`;
 
             const cells = versions.map(v => {
-              const file = `mc-${v}-survival.png`;
-              const ok = fs.existsSync(`${dir}/${file}`);
-              return ok
-                ? `<td align="center"><b>${v}</b><br><a href="${base}/${file}"><img src="${base}/${file}" width="200" alt="BetterHUD on Minecraft ${v}"></a></td>`
-                : `<td align="center"><b>${v}</b><br>❌ no screenshot</td>`;
+              const shots = [
+                { file: `mc-${v}-survival.png`, label: 'Survival World' },
+                { file: `mc-${v}-settings.png`, label: 'Settings Menu' },
+              ].map(({ file, label }) => fs.existsSync(`${dir}/${file}`)
+                ? `<a href="${base}/${file}"><img src="${base}/${file}" width="200" alt="BetterHUD ${label} on Minecraft ${v}"></a><br><sub>${label}</sub>`
+                : `❌ no ${label.toLowerCase()} screenshot`);
+              return `<td align="center"><b>${v}</b><br>${shots.join('<br>')}</td>`;
             });
             let rows = '';
             for (let i = 0; i < cells.length; i += 4) {
@@ -171,7 +176,7 @@ jobs:
             const body = [
               marker,
               '### Client Launch Test',
-              `Automated launch verification for \`${context.sha.slice(0, 7)}\`: on every supported Minecraft version, the client launched successfully and entered a survival singleplayer world with the HUD active. A ❌ indicates that a version's launch test did not produce a screenshot — see that version's job for details. Title-screen screenshots and game logs are available in the workflow run artifacts.`,
+              `Automated launch verification for \`${context.sha.slice(0, 7)}\`: on every supported Minecraft version, the client launched successfully, entered a survival singleplayer world with the HUD active, and opened the BetterHUD settings menu. A ❌ indicates that a version's launch test did not produce the corresponding screenshot — see that version's job for details. Title-screen screenshots and game logs are available in the workflow run artifacts.`,
               '',
               `<table>\n${rows}</table>`,
             ].join('\n');

--- a/README.md
+++ b/README.md
@@ -40,8 +40,9 @@ truth for every supported Minecraft version. It drives:
 - the Stonecutter variant list (`settings.gradle`),
 - the CI matrices — every push builds all variants and **launch-tests the mod
   on every supported version concurrently** (a real production client boots
-  under XVFB, enters a survival world with the HUD active, screenshots it,
-  and fails on any crash; the screenshots are posted as a grid on the PR),
+  under XVFB, enters a survival world with the HUD active, opens the BetterHUD
+  settings menu, screenshots both, and fails on any crash; the screenshots are
+  posted as a grid on the PR),
 - the per-version runtime mods used by those launch tests,
 - the Modrinth upload guide (see below).
 

--- a/launchtest/build.gradle
+++ b/launchtest/build.gradle
@@ -2,10 +2,10 @@
 //
 // Boots a REAL production Fabric client (fabric-loader + vanilla Minecraft +
 // the built betterhud jar + its runtime dependency mods) for ANY supported
-// Minecraft version, verifies the game reaches the title screen and a survival
-// singleplayer world with the HUD active, takes screenshots, and exits. Any
-// crash on the way fails the build. The Minecraft version to launch is chosen
-// with a Gradle property:
+// Minecraft version, verifies the game reaches the title screen, a survival
+// singleplayer world with the HUD active, and the BetterHUD settings menu,
+// takes screenshots, and exits. Any crash on the way fails the build. The
+// Minecraft version to launch is chosen with a Gradle property:
 //
 //   ./gradlew :launchtest:runProductionClientGameTest -PtestMcVersion=1.21.3
 //
@@ -89,16 +89,20 @@ if (entry.clientGametest) {
 dependencies {
 	minecraft "com.mojang:minecraft:${testMcVersion}"
 
+	// Mod Menu's API is compiled against so the test driver can open BetterHUD's
+	// settings screen through the mod's registered "modmenu" entrypoint.
 	if (isLegacy) {
 		mappings loom.officialMojangMappings()
 		modImplementation "net.fabricmc:fabric-loader:${loaderVersion}"
 		modImplementation "net.fabricmc.fabric-api:fabric-api:${entry.fabricApi}"
+		modCompileOnly "com.terraformersmc:modmenu:${entry.modmenu}"
 		if (entry.clientGametest) {
 			modImplementation fabricApi.module('fabric-client-gametest-api-v1', entry.fabricApi)
 		}
 	} else {
 		implementation "net.fabricmc:fabric-loader:${loaderVersion}"
 		implementation "net.fabricmc.fabric-api:fabric-api:${entry.fabricApi}"
+		compileOnly "com.terraformersmc:modmenu:${entry.modmenu}"
 		implementation fabricApi.module('fabric-client-gametest-api-v1', entry.fabricApi)
 	}
 
@@ -136,7 +140,8 @@ def ownJarTask = tasks.names.contains('remapJar') ? 'remapJar' : 'jar'
 
 // Launches a real production Fabric client and runs the launch test: reach the
 // title screen, enter a survival singleplayer world with the HUD rendering,
-// screenshot it (run/screenshots/), and shut down cleanly.
+// open the BetterHUD settings menu, screenshot both (run/screenshots/), and
+// shut down cleanly.
 tasks.register('runProductionClientGameTest', net.fabricmc.loom.task.prod.ClientProductionRunTask) {
 	mods.setFrom(variantProject.tasks.named(variantJarTask), tasks.named(ownJarTask), configurations.productionRuntimeMods)
 

--- a/launchtest/src/fallback/java/dsns/betterhud/gametest/LaunchTestClient.java
+++ b/launchtest/src/fallback/java/dsns/betterhud/gametest/LaunchTestClient.java
@@ -1,9 +1,12 @@
 package dsns.betterhud.gametest;
 
+import com.terraformersmc.modmenu.api.ModMenuApi;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.Screenshot;
+import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.TitleScreen;
 
 /**
@@ -13,17 +16,20 @@ import net.minecraft.client.gui.screens.TitleScreen;
  * <p>When the run is started with {@code --quickPlaySingleplayer ci-world} and
  * {@code -Dbetterhud.launchtest.expectWorld=true} (see the launchtest Gradle
  * project), the game joins the pre-generated survival world; once it has ticked
- * long enough for chunks to render with the HUD active, this mod screenshots it
- * and schedules a clean shutdown, making the client exit with code 0. Without a
- * pre-generated world it screenshots the title screen and shuts down there
- * instead. A crash anywhere on the way fails the run.
+ * long enough for chunks to render with the HUD active, this mod screenshots it,
+ * opens and screenshots the BetterHUD settings menu, and schedules a clean
+ * shutdown, making the client exit with code 0. Without a pre-generated world it
+ * screenshots the title screen and shuts down there instead. A crash anywhere on
+ * the way fails the run.
  */
 public class LaunchTestClient implements ClientModInitializer {
 	private static final boolean EXPECT_WORLD = Boolean.getBoolean("betterhud.launchtest.expectWorld");
 
 	// 200 ticks (10s) gives the software renderer on CI time to draw chunks.
 	private static final int WORLD_SCREENSHOT_TICK = 200;
-	private static final int WORLD_STOP_TICK = 240;
+	private static final int SETTINGS_OPEN_TICK = 220;
+	private static final int SETTINGS_SCREENSHOT_TICK = 260;
+	private static final int WORLD_STOP_TICK = 280;
 	private static final int TITLE_SCREENSHOT_TICK = 40;
 	private static final int TITLE_STOP_TICK = 80;
 	// 2400 ticks (2min) is plenty to join the pre-generated flat world; bail
@@ -48,6 +54,10 @@ public class LaunchTestClient implements ClientModInitializer {
 				worldTicks++;
 				if (worldTicks == WORLD_SCREENSHOT_TICK) {
 					takeScreenshot(client, "betterhud-survival-world");
+				} else if (worldTicks == SETTINGS_OPEN_TICK) {
+					client.setScreen(createSettingsScreen(client));
+				} else if (worldTicks == SETTINGS_SCREENSHOT_TICK) {
+					takeScreenshot(client, "betterhud-settings-menu");
 				} else if (worldTicks == WORLD_STOP_TICK) {
 					client.stop();
 				}
@@ -60,6 +70,24 @@ public class LaunchTestClient implements ClientModInitializer {
 				}
 			}
 		});
+	}
+
+	/**
+	 * Builds BetterHUD's settings screen the same way Mod Menu does: through the
+	 * config screen factory that the mod registers via its "modmenu" entrypoint.
+	 */
+	private static Screen createSettingsScreen(Minecraft client) {
+		ModMenuApi entrypoint = FabricLoader.getInstance()
+				.getEntrypointContainers("modmenu", ModMenuApi.class).stream()
+				.filter(container -> "betterhud".equals(container.getProvider().getMetadata().getId()))
+				.findFirst()
+				.orElseThrow(() -> new AssertionError("BetterHUD does not register a \"modmenu\" entrypoint"))
+				.getEntrypoint();
+		Screen screen = entrypoint.getModConfigScreenFactory().create(client.screen);
+		if (screen == null) {
+			throw new AssertionError("BetterHUD did not provide a settings screen (is Cloth Config loaded?)");
+		}
+		return screen;
 	}
 
 	private static void takeScreenshot(Minecraft client, String name) {

--- a/launchtest/src/fallback/resources/fabric.mod.json
+++ b/launchtest/src/fallback/resources/fabric.mod.json
@@ -3,7 +3,7 @@
 	"id": "betterhud-gametest",
 	"version": "1.0.0",
 	"name": "BetterHUD Launch Test",
-	"description": "Fallback launch test for BetterHUD on Minecraft versions without Fabric's client gametest module: screenshots the (pre-generated) survival world or the title screen, then exits.",
+	"description": "Fallback launch test for BetterHUD on Minecraft versions without Fabric's client gametest module: screenshots the (pre-generated) survival world and the BetterHUD settings menu, or the title screen, then exits.",
 	"license": "AGPL-3.0",
 	"environment": "client",
 	"entrypoints": {
@@ -11,6 +11,8 @@
 	},
 	"depends": {
 		"betterhud": "*",
-		"fabric-lifecycle-events-v1": "*"
+		"fabric-lifecycle-events-v1": "*",
+		"modmenu": "*",
+		"cloth-config2": "*"
 	}
 }

--- a/launchtest/src/gametest-legacy/java/dsns/betterhud/gametest/BetterHudClientGameTest.java
+++ b/launchtest/src/gametest-legacy/java/dsns/betterhud/gametest/BetterHudClientGameTest.java
@@ -10,9 +10,13 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import com.terraformersmc.modmenu.api.ModMenuApi;
 import net.fabricmc.fabric.api.client.gametest.v1.FabricClientGameTest;
 import net.fabricmc.fabric.api.client.gametest.v1.context.ClientGameTestContext;
 import net.fabricmc.fabric.api.client.gametest.v1.context.TestSingleplayerContext;
+import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.worldselection.WorldCreationUiState;
 
 @SuppressWarnings("UnstableApiUsage")
@@ -29,7 +33,32 @@ public class BetterHudClientGameTest implements FabricClientGameTest {
 			// Let the world tick a little with the HUD rendering before capturing evidence.
 			context.waitTicks(40);
 			assertScreenshotSaved(context.takeScreenshot("betterhud-survival-world"));
+
+			// Open the BetterHUD settings menu and capture it too, so the
+			// settings configuration can be validated per version.
+			context.runOnClient(client -> client.setScreen(createSettingsScreen(client)));
+			context.waitTicks(20);
+			assertScreenshotSaved(context.takeScreenshot("betterhud-settings-menu"));
+			context.runOnClient(client -> client.setScreen(null));
 		}
+	}
+
+	/**
+	 * Builds BetterHUD's settings screen the same way Mod Menu does: through the
+	 * config screen factory that the mod registers via its "modmenu" entrypoint.
+	 */
+	private static Screen createSettingsScreen(Minecraft client) {
+		ModMenuApi entrypoint = FabricLoader.getInstance()
+				.getEntrypointContainers("modmenu", ModMenuApi.class).stream()
+				.filter(container -> "betterhud".equals(container.getProvider().getMetadata().getId()))
+				.findFirst()
+				.orElseThrow(() -> new AssertionError("BetterHUD does not register a \"modmenu\" entrypoint"))
+				.getEntrypoint();
+		Screen screen = entrypoint.getModConfigScreenFactory().create(client.screen);
+		if (screen == null) {
+			throw new AssertionError("BetterHUD did not provide a settings screen (is Cloth Config loaded?)");
+		}
+		return screen;
 	}
 
 	private static void assertScreenshotSaved(Path screenshot) {

--- a/src/gametest/java/dsns/betterhud/gametest/BetterHudClientGameTest.java
+++ b/src/gametest/java/dsns/betterhud/gametest/BetterHudClientGameTest.java
@@ -5,9 +5,13 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import com.terraformersmc.modmenu.api.ModMenuApi;
 import net.fabricmc.fabric.api.client.gametest.v1.FabricClientGameTest;
 import net.fabricmc.fabric.api.client.gametest.v1.context.ClientGameTestContext;
 import net.fabricmc.fabric.api.client.gametest.v1.context.TestSingleplayerContext;
+import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.worldselection.WorldCreationUiState;
 
 @SuppressWarnings("UnstableApiUsage")
@@ -24,7 +28,32 @@ public class BetterHudClientGameTest implements FabricClientGameTest {
 			// Let the world tick a little with the HUD rendering before capturing evidence.
 			context.waitTicks(40);
 			assertScreenshotSaved(context.takeScreenshot("betterhud-survival-world"));
+
+			// Open the BetterHUD settings menu and capture it too, so the
+			// settings configuration can be validated per version.
+			context.runOnClient(client -> client.setScreen(createSettingsScreen(client)));
+			context.waitTicks(20);
+			assertScreenshotSaved(context.takeScreenshot("betterhud-settings-menu"));
+			context.runOnClient(client -> client.setScreen(null));
 		}
+	}
+
+	/**
+	 * Builds BetterHUD's settings screen the same way Mod Menu does: through the
+	 * config screen factory that the mod registers via its "modmenu" entrypoint.
+	 */
+	private static Screen createSettingsScreen(Minecraft client) {
+		ModMenuApi entrypoint = FabricLoader.getInstance()
+				.getEntrypointContainers("modmenu", ModMenuApi.class).stream()
+				.filter(container -> "betterhud".equals(container.getProvider().getMetadata().getId()))
+				.findFirst()
+				.orElseThrow(() -> new AssertionError("BetterHUD does not register a \"modmenu\" entrypoint"))
+				.getEntrypoint();
+		Screen screen = entrypoint.getModConfigScreenFactory().create(client.screen);
+		if (screen == null) {
+			throw new AssertionError("BetterHUD did not provide a settings screen (is Cloth Config loaded?)");
+		}
+		return screen;
 	}
 
 	private static void assertScreenshotSaved(Path screenshot) {

--- a/src/gametest/resources/fabric.mod.json
+++ b/src/gametest/resources/fabric.mod.json
@@ -11,6 +11,8 @@
 	},
 	"depends": {
 		"betterhud": "*",
-		"fabric-client-gametest-api-v1": "*"
+		"fabric-client-gametest-api-v1": "*",
+		"modmenu": "*",
+		"cloth-config2": "*"
 	}
 }


### PR DESCRIPTION
## Summary
Extends the launch test suite to verify that the BetterHUD settings menu opens and renders correctly on all supported Minecraft versions, in addition to the existing survival world verification.

## Key Changes

- **Launch test logic**: Modified test drivers to open the BetterHUD settings menu after the survival world renders, take a screenshot of it, then shut down cleanly
  - Updated `LaunchTestClient` (fallback for older versions) with new tick timings for opening and screenshotting the settings menu
  - Updated `BetterHudClientGameTest` (modern gametest API) to open and screenshot the settings menu
  
- **Settings screen creation**: Implemented `createSettingsScreen()` helper method that uses the Mod Menu API to instantiate BetterHUD's config screen the same way Mod Menu does, ensuring proper initialization through the "modmenu" entrypoint

- **Screenshot verification**: Updated the CI workflow to check for both `*betterhud-survival-world.png` and `*betterhud-settings-menu.png` screenshots before considering a launch test successful

- **Screenshot reporting**: Enhanced the PR comment grid to display both survival world and settings menu screenshots side-by-side for each Minecraft version, with labeled links and fallback indicators for missing screenshots

- **Dependencies**: Added Mod Menu and Cloth Config as compile-only/mod-only dependencies to the launchtest module so the test driver can access the settings screen factory

- **Documentation**: Updated workflow comments, README, and Gradle build comments to reflect the expanded test scope

## Implementation Details

The settings menu is opened 20 ticks after the survival world screenshot (tick 220 vs 200), allowing time for the world to stabilize. The screenshot is taken at tick 260, giving the menu time to render. The shutdown is delayed to tick 280 to ensure both operations complete.

The `createSettingsScreen()` method uses FabricLoader's entrypoint API to find BetterHUD's "modmenu" entrypoint and calls its config screen factory, matching Mod Menu's own behavior. This ensures the settings screen is properly initialized with all dependencies.

https://claude.ai/code/session_013zmpZPFUSYFS91nJRCYyd7