### PR TITLE
Remove comments from all files outside src/main

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,3 @@
-#
-# https://help.github.com/articles/dealing-with-line-endings/
-#
-# Linux start script should use lf
 /gradlew        text eol=lf
 
-# These are Windows script files and should use crlf
 *.bat           text eol=crlf
-

--- a/.github/scripts/generate-matrices.sh
+++ b/.github/scripts/generate-matrices.sh
@@ -1,14 +1,4 @@
 #!/usr/bin/env bash
-# Derives the CI job matrices from supported-versions.json (the single source
-# of truth for supported Minecraft versions) and writes them to GITHUB_OUTPUT:
-#  - build:   one entry per build variant       -> { mc, java }
-#  - launch:  one entry per launchable version  -> { mc, java, pregen_world }
-#  - publish: one entry per build variant       -> { mc, java, game_versions, range }
-# pregen_world marks versions whose Fabric API has no client gametest module;
-# their launch test needs a pre-generated world (see generate-test-world.sh).
-# game_versions is the newline-separated list of Minecraft versions the
-# variant's jar covers (fed to mc-publish), range is its human-readable form
-# for the release name (e.g. "1.21-1.21.5").
 set -euo pipefail
 
 JSON=supported-versions.json

--- a/.github/scripts/generate-test-world.sh
+++ b/.github/scripts/generate-test-world.sh
@@ -1,13 +1,4 @@
 #!/usr/bin/env bash
-# Generates a vanilla singleplayer world save for the given Minecraft version
-# by briefly running that version's dedicated server, and places it where the
-# launch test expects it (launchtest/run/saves/ci-world).
-#
-# Only needed for versions whose Fabric API has no client gametest module
-# (before 1.21.4): their launch test cannot create a world in-game, so the
-# client auto-joins this save via --quickPlaySingleplayer instead. Using the
-# exact same Minecraft version to generate the world avoids any world-upgrade
-# prompts when the client opens it.
 set -euo pipefail
 
 MC_VERSION="${1:?usage: generate-test-world.sh <minecraft-version>}"
@@ -22,8 +13,6 @@ SERVER_URL="$(curl -sSf "$MANIFEST_URL" | jq -r '.downloads.server.url')"
 curl -sSfo server.jar "$SERVER_URL"
 
 echo "eula=true" > eula.txt
-# A flat world keeps generation fast and renders instantly on the CI software
-# renderer. The default gamemode (survival) matches the gametest-based runs.
 cat > server.properties <<'EOF'
 level-name=ci-world
 level-type=minecraft\:flat

--- a/.github/scripts/publish-screenshots.sh
+++ b/.github/scripts/publish-screenshots.sh
@@ -1,20 +1,10 @@
 #!/usr/bin/env bash
-# Collects the launch-test screenshots uploaded as artifacts by every matrix
-# job of the current workflow run, normalizes their names, and commits them to
-# the ci-screenshots branch so they can be embedded (as raw.githubusercontent
-# URLs) in a PR comment and in the job summary.
-#
-# Leaves the normalized screenshots in screenshots-publish/ for the comment
-# step: <sha>/mc-<version>-survival.png and <sha>/mc-<version>-title.png.
-#
-# Required env: GITHUB_TOKEN, GITHUB_REPOSITORY, GITHUB_RUN_ID, GITHUB_SHA
 set -euo pipefail
 
 api() {
 	curl -sSf -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" "$@"
 }
 
-# --- Download every launch-screenshots-mc* artifact of this run -------------
 mkdir -p artifact-zips shots
 api "https://api.github.com/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/artifacts?per_page=100" > artifacts.json
 
@@ -28,7 +18,6 @@ while IFS=: read -r id name; do
 	unzip -oq "artifact-zips/$id.zip" -d "shots/$mc"
 done < <(jq -r '.artifacts[] | select(.name | startswith("launch-screenshots-mc")) | "\(.id):\(.name)"' artifacts.json)
 
-# --- Normalize names (gametest screenshots carry a timestamp prefix) --------
 PUBLISH="screenshots-publish/$GITHUB_SHA"
 mkdir -p "$PUBLISH"
 
@@ -49,7 +38,6 @@ if [ "$count" -eq 0 ]; then
 	exit 0
 fi
 
-# --- Commit to the ci-screenshots branch ------------------------------------
 REMOTE="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 if ! git clone --quiet --depth 1 --branch ci-screenshots "$REMOTE" ci-screenshots-branch 2>/dev/null; then
 	mkdir -p ci-screenshots-branch
@@ -68,7 +56,6 @@ fi
 git -c user.name="github-actions[bot]" -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
 	commit --quiet -m "CI screenshots for $GITHUB_SHA"
 
-# Retry the push in case a concurrent run updated the branch first.
 for _ in 1 2 3; do
 	if git push --quiet origin ci-screenshots; then
 		echo "Published screenshots to ci-screenshots/$GITHUB_SHA"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,20 +1,6 @@
-# Build the mod for every Stonecutter variant, then launch-test the built jars
-# on EVERY supported Minecraft version concurrently: each launch job boots a
-# real production Fabric client under XVFB with the covering variant's jar and
-# version-matched runtime mods, enters a survival singleplayer world with the
-# HUD active, screenshots it, and fails if anything crashes on the way.
-# The screenshot report job embeds all screenshots in a PR comment (via the
-# ci-screenshots branch) and in the job summary, and the modrinth bundle job
-# packages the release jars with their per-jar Minecraft version lists.
-#
-# Both job matrices are generated from supported-versions.json — add a version
-# there (see README) and every job picks it up.
-
 name: build
 on: push
 
-# contents: write lets the screenshot report push to the ci-screenshots branch,
-# pull-requests: write lets it comment on the associated pull request.
 permissions:
   contents: write
   pull-requests: write
@@ -67,14 +53,6 @@ jobs:
           name: betterhud-mc${{ matrix.mc }}
           path: versions/${{ matrix.mc }}/build/libs/*.jar
 
-  # One job per supported Minecraft version (not per build variant): the
-  # 1.21 variant jar is launch-tested on 1.21-1.21.5, the 1.21.6 variant jar
-  # on 1.21.6-1.21.11, and so on.
-  #
-  # pregen_world marks versions whose Fabric API has no client gametest module
-  # (before 1.21.4): for those a vanilla world save is generated first with
-  # that version's dedicated server, and the client auto-joins it instead of
-  # creating one through the gametest API.
   launch-test:
     name: launch mc${{ matrix.mc }}
     runs-on: ubuntu-24.04
@@ -101,7 +79,6 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: install xvfb
-        # Provides a virtual display so the Minecraft client can launch headlessly.
         run: sudo apt-get update && sudo apt-get install -y xvfb
 
       - name: generate singleplayer test world
@@ -115,7 +92,6 @@ jobs:
         run: test -n "$(find launchtest/run/screenshots -name '*betterhud-survival-world.png' -print -quit 2>/dev/null)"
 
       - name: upload screenshots
-        # Consumed by the screenshot-report job below.
         if: always()
         uses: actions/upload-artifact@v7
         with:
@@ -175,7 +151,6 @@ jobs:
               `<table>\n${rows}</table>`,
             ].join('\n');
 
-            // Always show the grid in the job summary, even without a PR.
             await core.summary.addRaw(body).write();
 
             const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
@@ -189,7 +164,6 @@ jobs:
               return;
             }
 
-            // Keep a single comment up to date instead of posting one per push.
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner, repo: context.repo.repo,
               issue_number: pr.number, per_page: 100,
@@ -207,9 +181,6 @@ jobs:
               });
             }
 
-  # Builds every variant and bundles the release jars together with UPLOAD.md,
-  # which lists exactly which Minecraft versions to select for each jar when
-  # uploading to Modrinth. Download the "modrinth-upload" artifact and follow it.
   modrinth-bundle:
     name: modrinth bundle
     runs-on: ubuntu-24.04

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,20 +1,3 @@
-# Publishes the mod to Modrinth and CurseForge on demand: bump `mod_version`
-# in gradle.properties, push, then run this workflow from the Actions tab.
-# It builds every Stonecutter variant and uploads each release jar as its own
-# version on both platforms, selecting exactly the Minecraft versions that jar
-# covers — driven by supported-versions.json, the same single source of truth
-# the build and launch-test matrices use.
-#
-# Required repository secrets (Settings -> Secrets and variables -> Actions):
-#  - MODRINTH_TOKEN:   Modrinth PAT with the "Create versions" scope
-#                      (https://modrinth.com/settings/pats)
-#  - CURSEFORGE_TOKEN: CurseForge API token
-#                      (https://legacy.curseforge.com/account/api-tokens)
-#
-# This workflow only builds; correctness on every supported Minecraft version
-# is already covered by the launch tests that run on every push (build.yml),
-# so make sure the commit you release from is green there first.
-
 name: publish
 on:
   workflow_dispatch:
@@ -45,7 +28,6 @@ on:
 permissions:
   contents: read
 
-# Never let two release runs interleave their uploads.
 concurrency:
   group: publish
   cancel-in-progress: false
@@ -73,9 +55,6 @@ jobs:
           echo "Releasing BetterHUD $version"
 
       - name: check the required tokens are configured
-        # mc-publish silently skips a platform whose token is empty, which
-        # would make a run "succeed" while publishing nothing — fail early
-        # instead if a selected platform has no token.
         env:
           PLATFORMS: ${{ inputs.platforms }}
           MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
@@ -93,9 +72,6 @@ jobs:
     runs-on: ubuntu-24.04
     needs: matrices
     strategy:
-      # Publish one variant at a time, oldest first (supported-versions.json
-      # order), so the newest-Minecraft version ends up as the most recently
-      # uploaded — and a failure stops before uploading the rest.
       max-parallel: 1
       fail-fast: true
       matrix:
@@ -122,8 +98,6 @@ jobs:
       - name: publish to modrinth and curseforge
         uses: Kir-Antipov/mc-publish@v3.3
         with:
-          # An empty token makes mc-publish skip that platform, which is how
-          # the "platforms" input narrows the run to a single site.
           modrinth-id: betterhudfabric
           modrinth-token: ${{ inputs.platforms != 'curseforge' && secrets.MODRINTH_TOKEN || '' }}
           curseforge-id: 1375095

--- a/.gitignore
+++ b/.gitignore
@@ -1,22 +1,14 @@
-# gradle
-
 .gradle/
 build/
 out/
 classes/
 
-# eclipse
-
 *.launch
-
-# idea
 
 .idea/
 *.iml
 *.ipr
 *.iws
-
-# vscode
 
 .settings/
 .vscode/
@@ -24,23 +16,15 @@ bin/
 .classpath
 .project
 
-# macos
-
 *.DS_Store
 
-# fabric
-
 run/
-
-# stonecutter
 
 versions/*/.gradle/
 versions/*/build/
 versions/*/run/
 versions/*/src/
 *.stonecutter.tmp
-
-# java
 
 hs_err_*.log
 replay_*.log

--- a/build.gradle
+++ b/build.gradle
@@ -1,20 +1,15 @@
 plugins {
-	// Loom 1.14+ splits into two sibling plugins:
-	//  - `net.fabricmc.fabric-loom-remap` handles obfuscated MC (1.21.x with intermediary)
-	//  - `net.fabricmc.fabric-loom`       handles unobfuscated MC (26.1+, Mojang names native)
-	// We declare both with `apply false` and pick the right one for the current variant.
 	id 'net.fabricmc.fabric-loom-remap' version "${loom_version}" apply false
 	id 'net.fabricmc.fabric-loom' version "${loom_version}" apply false
 	id 'maven-publish'
 }
 
 def mcVersion = stonecutter.current.version
-def isLegacy = stonecutter.eval(mcVersion, '<26')      // 1.21.x family
-def hasHudElementRegistry = stonecutter.eval(mcVersion, '>=1.21.6')  // 1.21.6+ and 26+
+def isLegacy = stonecutter.eval(mcVersion, '<26')
+def hasHudElementRegistry = stonecutter.eval(mcVersion, '>=1.21.6')
 
 apply plugin: isLegacy ? 'net.fabricmc.fabric-loom-remap' : 'net.fabricmc.fabric-loom'
 
-// Per-MC Java version (21 for 1.21.x, 25 for 26.1+).
 def javaVersionInt = Integer.parseInt(project.java_version)
 def javaLang = JavaVersion.toVersion(javaVersionInt)
 def mixinJavaCompat = "JAVA_${javaVersionInt}"
@@ -31,8 +26,6 @@ repositories {
 	maven { url 'https://maven.terraformersmc.com/releases/' }
 }
 
-// MC 26+ uses fabric-rendering-v1's transitive deps but rejects ASM coming from
-// annotation processors.
 if (!isLegacy) {
 	configurations.configureEach {
 		if (name.toLowerCase().contains('annotationprocessor')) {
@@ -41,9 +34,6 @@ if (!isLegacy) {
 	}
 }
 
-// Every variant declares fabric-api, modmenu, and cloth-config as runtime deps
-// (not bundled). 1.21.x uses modImplementation for intermediary remapping; 26.x
-// uses plain implementation against unobfuscated MC.
 dependencies {
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
 
@@ -118,6 +108,5 @@ publishing {
 		}
 	}
 	repositories {
-		// Add publish repos here if/when needed.
 	}
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,18 +1,12 @@
-# Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx2G
 org.gradle.parallel=true
 
-# IntelliJ IDEA is not yet fully compatible with configuration cache, see: https://github.com/FabricMC/fabric-loom/issues/1349
 org.gradle.configuration-cache=false
 
-# Acknowledge using Groovy DSL with Stonecutter (Kotlin DSL is recommended but Groovy works).
 dev.kikugie.stonecutter.hard_mode=true
 
-# Single loom version covers all MC variants. The `fabric-loom-remap` plugin id
-# handles obfuscated MC (1.21.x), while `fabric-loom` handles unobfuscated MC (26.2+).
 loom_version=1.17-SNAPSHOT
 
-# Mod Properties (shared)
 mod_version=2.1.1
 maven_group=dsns.betterhud
 archives_base_name=betterhud

--- a/launchtest/build.gradle
+++ b/launchtest/build.gradle
@@ -1,43 +1,8 @@
-// Production client launch test harness.
-//
-// Boots a REAL production Fabric client (fabric-loader + vanilla Minecraft +
-// the built betterhud jar + its runtime dependency mods) for ANY supported
-// Minecraft version, verifies the game reaches the title screen and a survival
-// singleplayer world with the HUD active, takes screenshots, and exits. Any
-// crash on the way fails the build. The Minecraft version to launch is chosen
-// with a Gradle property:
-//
-//   ./gradlew :launchtest:runProductionClientGameTest -PtestMcVersion=1.21.3
-//
-// Loom's ClientProductionRunTask is hard-wired to the project's Minecraft
-// version, so this project applies Loom with `testMcVersion` as its Minecraft
-// version, then launches the jar built by the Stonecutter variant that covers
-// that version. On Linux CI (CI env var set) Loom runs the game under XVFB.
-//
-// The test driver mod compiled by this project comes in three flavours,
-// because Fabric's client gametest API only exists from 1.21.4:
-//  - 26.x:           /src/gametest (Mojang-style gametest API names, 5.x)
-//  - 1.21.4-1.21.11: src/gametest-legacy (same test, Yarn-style API names)
-//  - 1.21-1.21.3:    src/fallback (no gametest API: joins a pre-generated
-//                    world via --quickPlaySingleplayer, screenshots, exits;
-//                    see .github/scripts/generate-test-world.sh)
-
 plugins {
 	id 'net.fabricmc.fabric-loom-remap' version "${loom_version}" apply false
 	id 'net.fabricmc.fabric-loom' version "${loom_version}" apply false
 }
 
-// ---------------------------------------------------------------------------
-// supported-versions.json (repo root) is the single source of truth for the
-// launchable Minecraft versions. Per version it pins:
-//  - variant:        the Stonecutter build variant whose jar covers it
-//  - fabricApi:      newest Fabric API built for exactly this version
-//  - modmenu:        newest Mod Menu whose fabric.mod.json accepts this version
-//  - cloth:          newest Cloth Config whose fabric.mod.json accepts this version
-//  - clientGametest: whether this Fabric API provides fabric-client-gametest-api-v1
-//                    (absent before 1.21.4; those versions use src/fallback)
-// All mod versions were verified against each jar's declared `depends` range.
-// ---------------------------------------------------------------------------
 def supportedVersions = new groovy.json.JsonSlurper().parse(new File(rootDir, 'supported-versions.json'))
 
 def testMcVersion = providers.gradleProperty('testMcVersion').getOrElse(supportedVersions.keySet().last())
@@ -46,15 +11,11 @@ if (entry == null) {
 	throw new GradleException("Unsupported testMcVersion '${testMcVersion}'. Supported versions: ${supportedVersions.keySet().join(', ')}")
 }
 
-// Reuse the covering variant's loader and Java versions so the launch matches
-// what that variant is built and shipped for.
 def variantProps = new Properties()
 file("../versions/${entry.variant}/gradle.properties").withInputStream { variantProps.load(it) }
 def loaderVersion = variantProps.getProperty('loader_version')
 def javaVersionInt = Integer.parseInt(variantProps.getProperty('java_version'))
 
-// Same plugin split as the variant builds: obfuscated 1.21.x needs the remap
-// plugin (intermediary production namespace), 26.x runs Mojang names natively.
 def isLegacy = entry.variant.startsWith('1.')
 apply plugin: isLegacy ? 'net.fabricmc.fabric-loom-remap' : 'net.fabricmc.fabric-loom'
 
@@ -68,7 +29,6 @@ repositories {
 	maven { url 'https://maven.terraformersmc.com/releases/' }
 }
 
-// Matches the variant builds: MC 26+ rejects ASM coming from annotation processors.
 if (!isLegacy) {
 	configurations.configureEach {
 		if (name.toLowerCase().contains('annotationprocessor')) {
@@ -77,7 +37,6 @@ if (!isLegacy) {
 	}
 }
 
-// Pick the test driver source flavour for this Minecraft version (see header).
 if (entry.clientGametest) {
 	sourceSets.main.java.srcDirs = [isLegacy ? 'src/gametest-legacy/java' : "${rootDir}/src/gametest/java"]
 	sourceSets.main.resources.srcDirs = ["${rootDir}/src/gametest/resources"]
@@ -102,17 +61,11 @@ dependencies {
 		implementation fabricApi.module('fabric-client-gametest-api-v1', entry.fabricApi)
 	}
 
-	// Mods loaded alongside the built betterhud jar by the production run.
-	// These are production (intermediary/official) jars straight off the mod
-	// mavens; transitive deps are excluded because each fat jar already nests
-	// everything it needs via jar-in-jar.
 	productionRuntimeMods("net.fabricmc.fabric-api:fabric-api:${entry.fabricApi}") { transitive = false }
 	productionRuntimeMods("com.terraformersmc:modmenu:${entry.modmenu}") { transitive = false }
 	productionRuntimeMods("me.shedaniel.cloth:cloth-config-fabric:${entry.cloth}") { transitive = false }
 
 	if (entry.clientGametest) {
-		// Handles -Dfabric.client.gametest in the production client. Not part
-		// of the fabric-api fat jar, so it is loaded as its own mod.
 		productionRuntimeMods(fabricApi.module('fabric-client-gametest-api-v1', entry.fabricApi)) { transitive = false }
 	}
 }
@@ -129,35 +82,21 @@ java {
 
 evaluationDependsOn(":${entry.variant}")
 def variantProject = project(":${entry.variant}")
-// 1.21.x projects ship the intermediary-remapped jar; 26.x projects ship the
-// plain jar (no remapping for unobfuscated Minecraft).
 def variantJarTask = variantProject.tasks.names.contains('remapJar') ? 'remapJar' : 'jar'
 def ownJarTask = tasks.names.contains('remapJar') ? 'remapJar' : 'jar'
 
-// Launches a real production Fabric client and runs the launch test: reach the
-// title screen, enter a survival singleplayer world with the HUD rendering,
-// screenshot it (run/screenshots/), and shut down cleanly.
 tasks.register('runProductionClientGameTest', net.fabricmc.loom.task.prod.ClientProductionRunTask) {
 	mods.setFrom(variantProject.tasks.named(variantJarTask), tasks.named(ownJarTask), configurations.productionRuntimeMods)
 
 	if (entry.clientGametest) {
-		// Fabric's client gametest runner drives the test and shuts the game
-		// down after the registered gametest (src/gametest) finishes.
 		jvmArgs.add('-Dfabric.client.gametest')
 		jvmArgs.add('-Dfabric.client.gametest.disableNetworkSynchronizer=true')
 	} else if (file('run/saves/ci-world').exists()) {
-		// No gametest API on this version: auto-join the pre-generated world;
-		// the fallback testmod screenshots it and stops the client. Without a
-		// pre-generated world the testmod stops at the title screen instead.
 		jvmArgs.add('-Dbetterhud.launchtest.expectWorld=true')
 		programArgs.addAll('--quickPlaySingleplayer', 'ci-world')
 	}
 
 	doFirst {
-		// On a fresh game dir Minecraft opens the accessibility onboarding
-		// screen instead of the title screen; disable it so the run always
-		// reaches the title screen. (The gametest module also forces this via
-		// mixin; the fallback testmod needs it done here.)
 		def options = new File(runDir.get().asFile, 'options.txt')
 		if (!options.exists()) {
 			options.parentFile.mkdirs()

--- a/launchtest/src/fallback/java/dsns/betterhud/gametest/LaunchTestClient.java
+++ b/launchtest/src/fallback/java/dsns/betterhud/gametest/LaunchTestClient.java
@@ -6,28 +6,13 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.Screenshot;
 import net.minecraft.client.gui.screens.TitleScreen;
 
-/**
- * Fallback launch test driver for Minecraft versions whose Fabric API predates
- * the client gametest module (before 1.21.4).
- *
- * <p>When the run is started with {@code --quickPlaySingleplayer ci-world} and
- * {@code -Dbetterhud.launchtest.expectWorld=true} (see the launchtest Gradle
- * project), the game joins the pre-generated survival world; once it has ticked
- * long enough for chunks to render with the HUD active, this mod screenshots it
- * and schedules a clean shutdown, making the client exit with code 0. Without a
- * pre-generated world it screenshots the title screen and shuts down there
- * instead. A crash anywhere on the way fails the run.
- */
 public class LaunchTestClient implements ClientModInitializer {
 	private static final boolean EXPECT_WORLD = Boolean.getBoolean("betterhud.launchtest.expectWorld");
 
-	// 200 ticks (10s) gives the software renderer on CI time to draw chunks.
 	private static final int WORLD_SCREENSHOT_TICK = 200;
 	private static final int WORLD_STOP_TICK = 240;
 	private static final int TITLE_SCREENSHOT_TICK = 40;
 	private static final int TITLE_STOP_TICK = 80;
-	// 2400 ticks (2min) is plenty to join the pre-generated flat world; bail
-	// out with a failure instead of hanging until the CI job timeout.
 	private static final int WORLD_JOIN_TIMEOUT_TICKS = 2400;
 
 	private int totalTicks;

--- a/launchtest/src/gametest-legacy/java/dsns/betterhud/gametest/BetterHudClientGameTest.java
+++ b/launchtest/src/gametest-legacy/java/dsns/betterhud/gametest/BetterHudClientGameTest.java
@@ -1,10 +1,5 @@
 package dsns.betterhud.gametest;
 
-// Copy of /src/gametest/.../BetterHudClientGameTest.java for Minecraft
-// 1.21.4-1.21.11, whose fabric-client-gametest-api-v1 (4.x) names the client
-// world accessor getClientWorld() instead of getClientLevel() (5.x, 26.x).
-// Keep the two files in sync when changing the test.
-
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
@@ -26,7 +21,6 @@ public class BetterHudClientGameTest implements FabricClientGameTest {
 				.create()) {
 			singleplayer.getClientWorld().waitForChunksRender();
 
-			// Let the world tick a little with the HUD rendering before capturing evidence.
 			context.waitTicks(40);
 			assertScreenshotSaved(context.takeScreenshot("betterhud-survival-world"));
 		}

--- a/settings.gradle
+++ b/settings.gradle
@@ -21,28 +21,17 @@ plugins {
 	id 'dev.kikugie.stonecutter' version '0.9.3'
 }
 
-// Every supported Minecraft version, and the build variant that covers it,
-// lives in supported-versions.json — the single source of truth also used by
-// the launch tests, the CI matrices, and the modrinthBundle task.
 def supportedVersions = new groovy.json.JsonSlurper().parse(file('supported-versions.json'))
 def variants = supportedVersions.values()*.variant.unique()
 
 stonecutter {
 	create(rootProject) {
-		// Each variant is one buildable subproject; the string is both the
-		// subproject name and the MC version it compiles against (see
-		// versions/<variant>/gradle.properties).
 		versions(*variants)
 
-		// vcsVersion is the variant whose form the sources are committed in
-		// (the "active" version when nothing else is selected).
 		vcsVersion = variants.last()
 	}
 }
 
 rootProject.name = 'betterhud'
 
-// Not a Stonecutter variant: a sourceless harness that launches a production
-// Fabric client for any supported MC version (-PtestMcVersion) with the
-// matching variant's built jar. Used by the CI launch-test matrix.
 include 'launchtest'

--- a/src/gametest/java/dsns/betterhud/gametest/BetterHudClientGameTest.java
+++ b/src/gametest/java/dsns/betterhud/gametest/BetterHudClientGameTest.java
@@ -21,7 +21,6 @@ public class BetterHudClientGameTest implements FabricClientGameTest {
 				.create()) {
 			singleplayer.getClientLevel().waitForChunksRender();
 
-			// Let the world tick a little with the HUD rendering before capturing evidence.
 			context.waitTicks(40);
 			assertScreenshotSaved(context.takeScreenshot("betterhud-survival-world"));
 		}

--- a/stonecutter.gradle
+++ b/stonecutter.gradle
@@ -2,26 +2,14 @@ plugins {
 	id 'dev.kikugie.stonecutter'
 }
 
-// The "active" version determines which variant the source tree currently shows
-// uncommented. Switch with `./gradlew "Set active version to <ver>"` (Stonecutter task).
 stonecutter.active('26.2') /* [SC] DO NOT EDIT */
 
-// Stonecutter 0.7+ no longer needs explicit `registerChiseled` task: running
-// `./gradlew build` from the root automatically runs `build` for every version
-// subproject. Per-version commands like `./gradlew :1.21:build` also work.
-
-// Groups every supported Minecraft version (supported-versions.json) by the
-// build variant whose jar covers it, e.g. '1.21' -> ['1.21', ..., '1.21.5'].
 def supportedVersions = new groovy.json.JsonSlurper().parse(file('supported-versions.json'))
 def gameVersionsByVariant = [:]
 supportedVersions.each { mc, info ->
 	gameVersionsByVariant.computeIfAbsent(info.variant) { [] } << mc
 }
 
-// Builds every variant and collects the release jars in build/modrinth/ along
-// with UPLOAD.md, which lists exactly which Minecraft versions to select for
-// each jar when uploading to Modrinth. CI publishes the same directory as the
-// "modrinth-upload" artifact on every push.
 tasks.register('modrinthBundle') {
 	group = 'publishing'
 	description = 'Collects the release jars and the per-jar Minecraft version lists for Modrinth.'

--- a/versions/1.21.6/gradle.properties
+++ b/versions/1.21.6/gradle.properties
@@ -2,12 +2,9 @@ minecraft_version=1.21.6
 loader_version=0.17.3
 java_version=21
 
-# fabric.mod.json range
 mc_dep=>=1.21.6 <1.22
 loader_dep=>=0.16.10
 
-# Fabric API + ecosystem (compile-time versions for this variant; the launch
-# tests pin per-version runtime versions in supported-versions.json).
 fabric_api_version=0.128.2+1.21.6
 modmenu_version=15.0.2
 cloth_config_version=19.0.147

--- a/versions/1.21/gradle.properties
+++ b/versions/1.21/gradle.properties
@@ -2,12 +2,9 @@ minecraft_version=1.21
 loader_version=0.17.3
 java_version=21
 
-# fabric.mod.json range
 mc_dep=>=1.21 <=1.21.5
 loader_dep=>=0.15.11
 
-# Fabric API + ecosystem (compile-time versions for this variant; the launch
-# tests pin per-version runtime versions in supported-versions.json).
 fabric_api_version=0.102.0+1.21
 modmenu_version=14.0.2
 cloth_config_version=19.0.147

--- a/versions/26.1/gradle.properties
+++ b/versions/26.1/gradle.properties
@@ -2,11 +2,9 @@ minecraft_version=26.1
 loader_version=0.19.2
 java_version=25
 
-# fabric.mod.json range
 mc_dep=>=26.1 <26.2
 loader_dep=>=0.19
 
-# Fabric API + ecosystem (runtime deps, not bundled)
 fabric_api_version=0.145.1+26.1
 modmenu_version=18.0.0-alpha.8
 cloth_config_version=26.1.154

--- a/versions/26.2/gradle.properties
+++ b/versions/26.2/gradle.properties
@@ -2,11 +2,9 @@ minecraft_version=26.2
 loader_version=0.19.3
 java_version=25
 
-# fabric.mod.json range
 mc_dep=>=26.2
 loader_dep=>=0.19
 
-# Fabric API + ecosystem (26.2 requires these as runtime deps, not bundled)
 fabric_api_version=0.154.0+26.2
 modmenu_version=18.0.0-alpha.8
 cloth_config_version=26.1.154


### PR DESCRIPTION
Strips comments from the Gradle build files, gradle.properties files, CI workflows and scripts, test Java sources, .gitignore, and .gitattributes. Shebangs, the Stonecutter-managed /* [SC] DO NOT EDIT */ marker, and the third-party Gradle wrapper scripts are left untouched.


Claude-Session: https://claude.ai/code/session_012sH912ZXuhhM5LwYAp34BQ