### PR TITLE
Remove redundant comments and Javadoc from HUD classes

### DIFF
--- a/src/main/java/dsns/betterhud/BetterHUDGUI.java
+++ b/src/main/java/dsns/betterhud/BetterHUDGUI.java
@@ -69,7 +69,6 @@ public class BetterHUDGUI implements ClientTickEvents.StartTick {
         /*if (client.options.hideGui) return;*/
         //?}
 
-        // The editor draws its own live preview of every element.
         //? if >=26.2 {
         if (client.gui.screen() instanceof HudEditorScreen) return;
         //?} else {

--- a/src/main/java/dsns/betterhud/HudEditorScreen.java
+++ b/src/main/java/dsns/betterhud/HudEditorScreen.java
@@ -29,12 +29,6 @@ import org.joml.Matrix3x2fStack;
 /*import com.mojang.blaze3d.vertex.PoseStack;*/
 //?}
 
-/**
- * A Lunar Client style HUD editor: every enabled element is shown live and
- * can be dragged anywhere on the screen, resized with the scroll wheel, and
- * snapped back to its corner stack with a right click. Closing the screen
- * (Escape) saves the layout to the config file.
- */
 public class HudEditorScreen extends Screen {
 
     private static final int SNAP_DISTANCE = 5;
@@ -49,8 +43,6 @@ public class HudEditorScreen extends Screen {
     private static final int BACKDROP_COLOR = 0x50000000;
     private static final int NO_LEVEL_BACKDROP_COLOR = 0xff181818;
 
-    // Opaque beveled grays so the Settings button reads as a button rather
-    // than as another HUD element (those are translucent black boxes).
     private static final int BUTTON_BORDER_COLOR = 0xff000000;
     private static final int BUTTON_BORDER_HOVERED_COLOR = 0xffffffff;
     private static final int BUTTON_BODY_COLOR = 0xff6c6c6c;
@@ -58,8 +50,6 @@ public class HudEditorScreen extends Screen {
     private static final int BUTTON_BEVEL_LIGHT_COLOR = 0xffb4b4b4;
     private static final int BUTTON_BEVEL_DARK_COLOR = 0xff414141;
 
-    // The title and the Settings button live in the center of the screen:
-    // people rarely place a HUD element there, so they stay visible.
     private static final float TITLE_SCALE = 2.0f;
     private static final float BUTTON_TEXT_SCALE = 1.25f;
     private static final int OUTLINE_COLOR = 0x66ffffff;
@@ -104,11 +94,6 @@ public class HudEditorScreen extends Screen {
         refreshElements();
     }
 
-    /**
-     * Rebuilds the preview text of every enabled element. Elements whose mod
-     * has nothing to show right now (e.g. Ping in singleplayer) get a
-     * placeholder so they can still be positioned.
-     */
     private void refreshElements() {
         Minecraft client = Minecraft.getInstance();
 
@@ -142,7 +127,6 @@ public class HudEditorScreen extends Screen {
     }
 
     private HudLayout.Placed elementAt(double mouseX, double mouseY) {
-        // Iterate backwards so the element drawn on top wins.
         for (int i = placedElements.size() - 1; i >= 0; i--) {
             HudLayout.Placed placed = placedElements.get(i);
             if (
@@ -185,8 +169,6 @@ public class HudEditorScreen extends Screen {
         BaseMod mod = owners.get(placed.text);
 
         if (button == 1) {
-            // Right click: dock the element. A custom-positioned element goes
-            // back to its corner stack; a docked one cycles to the next corner.
             ModSettings settings = mod.getModSettings();
             Setting customPosition = settings.getSetting("Custom Position");
             if (customPosition.getBooleanValue()) {
@@ -229,7 +211,6 @@ public class HudEditorScreen extends Screen {
         snappedCenterX = false;
         snappedCenterY = false;
 
-        // Snap to the screen edges and the screen center lines.
         double centerX = maxX / 2.0;
         double centerY = maxY / 2.0;
         if (Math.abs(x - centerX) <= SNAP_DISTANCE) {
@@ -370,8 +351,6 @@ public class HudEditorScreen extends Screen {
     ) {
         Minecraft client = Minecraft.getInstance();
 
-        // Opened from Mod Menu there may be no world behind the screen; use a
-        // solid backdrop instead of a translucent one.
         drawContext.fill(
             0,
             0,
@@ -437,7 +416,6 @@ public class HudEditorScreen extends Screen {
 
         drawSettingsButton(drawContext, client, mouseX, mouseY);
 
-        // The hints live at the bottom center, clear of the corner stacks.
         HudLayout.Placed described = draggedMod != null
             ? placedFor(draggedMod)
             : hovered;
@@ -484,8 +462,6 @@ public class HudEditorScreen extends Screen {
             return;
         }
 
-        // Classic button proportions (20px tall, text centered at
-        // (height - 8) / 2, ~10px side padding), scaled with the text.
         String label = I18n.get("betterhud.editor.settings");
         settingsButtonWidth =
             (int) ((client.font.width(label) + 20) * BUTTON_TEXT_SCALE);

--- a/src/main/java/dsns/betterhud/ModMenu.java
+++ b/src/main/java/dsns/betterhud/ModMenu.java
@@ -3,9 +3,6 @@ package dsns.betterhud;
 import com.terraformersmc.modmenu.api.ConfigScreenFactory;
 import com.terraformersmc.modmenu.api.ModMenuApi;
 
-// Optional integration: this entrypoint is only loaded when Mod Menu is
-// installed. Nothing else in the mod may reference this class, or the mod
-// would crash without Mod Menu.
 public class ModMenu implements ModMenuApi {
 
     @Override

--- a/src/main/java/dsns/betterhud/SettingsScreenBuilder.java
+++ b/src/main/java/dsns/betterhud/SettingsScreenBuilder.java
@@ -12,17 +12,8 @@ import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
 
-/**
- * Builds the Cloth Config settings screen opened from the HUD editor's
- * Settings button. Kept free of Mod Menu classes so the editor can use it
- * when Mod Menu is not installed; Cloth Config classes are only touched
- * after the isModLoaded check.
- */
 public final class SettingsScreenBuilder {
 
-    // Placement is edited by dragging in the HUD editor, so these settings
-    // stay out of the settings screen. They remain in the config file as the
-    // persistence format the editor writes.
     private static final Set<String> EDITOR_MANAGED_SETTINGS = Set.of(
         "Orientation",
         "Custom Position",
@@ -36,10 +27,6 @@ public final class SettingsScreenBuilder {
         return FabricLoader.getInstance().isModLoaded("cloth-config2");
     }
 
-    /**
-     * Builds the settings screen (everything except placement), or returns
-     * null when Cloth Config is not installed.
-     */
     public static Screen createSettingsScreen(Screen parent) {
         if (!settingsScreenAvailable()) {
             return null;

--- a/src/main/java/dsns/betterhud/util/HudLayout.java
+++ b/src/main/java/dsns/betterhud/util/HudLayout.java
@@ -4,11 +4,6 @@ import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import java.util.List;
 import net.minecraft.client.Minecraft;
 
-/**
- * Shared placement math for HUD elements. Both the in-game HUD renderer and
- * the HUD editor screen go through this class, so the editor preview always
- * matches what the HUD actually renders.
- */
 public final class HudLayout {
 
     public static final int VERTICAL_PADDING = 4;
@@ -48,12 +43,6 @@ public final class HudLayout {
         return (int) (h * text.scale);
     }
 
-    /**
-     * Computes the on-screen position of every element. Elements without a
-     * custom position stack downwards (or upwards) from their corner in list
-     * order; custom-positioned elements map their 0-100% coordinates onto the
-     * space the element can occupy without leaving the screen.
-     */
     public static List<Placed> layout(Minecraft client, List<CustomText> texts) {
         List<Placed> placed = new ObjectArrayList<>();
 

--- a/src/main/java/dsns/betterhud/util/HudRenderer.java
+++ b/src/main/java/dsns/betterhud/util/HudRenderer.java
@@ -12,10 +12,6 @@ import org.joml.Matrix3x2fStack;
 /*import com.mojang.blaze3d.vertex.PoseStack;*/
 //?}
 
-/**
- * Draws a single HUD element (background + text). Shared between the in-game
- * HUD and the HUD editor screen.
- */
 public final class HudRenderer {
 
     private HudRenderer() {}

--- a/src/main/java/dsns/betterhud/util/ModSettings.java
+++ b/src/main/java/dsns/betterhud/util/ModSettings.java
@@ -23,9 +23,6 @@ public class ModSettings {
         );
 
         settings.put("Custom Position", Setting.createBooleanSetting(false));
-        // Percentages (0-100) of the space the element can occupy without
-        // leaving the screen. Doubles so dragging in the HUD editor is smooth;
-        // old integer config values still parse.
         settings.put("Custom X", Setting.createDoubleSetting(0, 0, 100));
         settings.put("Custom Y", Setting.createDoubleSetting(0, 0, 100));
         settings.put("Text Color", Setting.createColorSetting(0xffffffff));


### PR DESCRIPTION
## Summary

- Removed inline comments, block comments, and Javadoc from 7 HUD-related source files
- Deleted 59 lines of comments across `HudEditorScreen`, `HudLayout`, `SettingsScreenBuilder`, `ModMenu`, `BetterHUDGUI`, `HudRenderer`, and `ModSettings`
- No functional code changes

## Testing

- Not run